### PR TITLE
populates from `element-lab` schema if available

### DIFF
--- a/element_session/export/__init__.py
+++ b/element_session/export/__init__.py
@@ -1,1 +1,2 @@
+from .nwb import session_to_nwb_dict
 from .nwb import session_to_nwb

--- a/element_session/export/nwb.py
+++ b/element_session/export/nwb.py
@@ -31,11 +31,12 @@ def session_to_nwb_dict(session_key):
       identifier='_'.join(session_identifier.values()),
       session_description=session_info['session_note'] if session_info['session_note'] else '',
       session_start_time=session_info['session_datetime'],
-      source_script_file_name='DataJoint element-session/export/nwb.py',
+      # source_script='DataJoint element-session NWB exporter',
+      # source_script_file_name='element-session/export/nwb.py',
       experimenter=list(experimenters)
       )
     for k in list(session_dict): # Drop blank entries
-      if len(session_dict[k]) == 0: elem_info.pop(k)
+      if len(str(session_dict[k])) == 0: elem_info.pop(k)
     return session_dict
 
 def session_to_nwb(session_key):
@@ -46,5 +47,5 @@ def session_to_nwb(session_key):
     :param session_key: entry in session.Session table
     :return: NWBFile object
     """
-  return NWBFile(session_to_nwb_dict(session_key))
+    return NWBFile(**session_to_nwb_dict(session_key))
 

--- a/element_session/export/nwb.py
+++ b/element_session/export/nwb.py
@@ -1,12 +1,13 @@
+import datajoint as dj
 import numpy as np
 from datetime import datetime
 from dateutil.tz import tzlocal
 from pynwb import NWBFile
 
 from element_session import session
+from element_lab.export import *
 
-
-def session_to_nwb(session_key):
+def session_to_nwb(session_key,lab_key=None,project_key=None,protocol_key=None):
     session_key = (session.Session & session_key).fetch1('KEY')
 
     session_identifier = {}
@@ -15,19 +16,54 @@ def session_to_nwb(session_key):
 
     session_info = (session.Session & session_key).join(session.SessionNote, left=True).fetch1()
 
-    experimenter_pk = np.setxor1d(session.SessionExperimenter.primary_key,
-                                  session.Session.primary_key)
-    experimenters = (session.SessionExperimenter & session_key).proj(
-        experimenter=f'CONCAT({"-".join(experimenter_pk)})').fetch('experimenter')
+    ## Broz: I'm not sure which fork has the upstream Experimenter table
+    # experimenter_pk = np.setxor1d(session.SessionExperimenter.primary_key,
+    #                               session.Session.primary_key)
+    # experimenters = (session.SessionExperimenter & session_key).proj(
+    #     experimenter=f'CONCAT({"-".join(experimenter_pk)})').fetch('experimenter')
 
-    return NWBFile(identifier='_'.join(session_identifier.values()),
-                   session_description=session_info['session_note'] if session_info['session_note'] else '',
-                   session_start_time=session_info['session_datetime'],
-                   file_create_date=datetime.now(tzlocal()),
-                   experimenter=list(experimenters)
-                   # data_collection='', # moved to elem-lab
-                   # institution='',
-                   # experiment_description='',
-                   # related_publications='',
-                   # keywords=[]
-                   )
+    if [x for x in (lab_key,project_key,protocol_key) if x is not None]:
+      lab_info=elemlab_to_nwb_dict(lab_key,project_key,protocol_key)
+    else: lab_info={}
+
+    return NWBFile(
+      ## Session info
+      identifier='_'.join(session_identifier.values()),
+      session_description=session_info['session_note'] if session_info['session_note'] else '',
+      session_start_time=session_info['session_datetime'],
+      # experimenter=list(experimenters)
+
+      ## Lab info
+      ## Broz: How can I limit to only items that exist, avoiding blank entries?
+      institution=(lab_info['institution']
+            if 'institution' in lab_info else ''),
+      lab=(lab_info['lab_name']
+            if 'lab_name' in lab_info else ''),
+      experiment_description=(lab_info['project_description']
+            if 'project_description' in lab_info else ''),
+      keywords=(lab_info['proj_keyw'] # list
+            if 'proj_keyw' in lab_info else []),
+      notes=(lab_info['protocol_description']
+            if 'protocol_description' in lab_info else ''),
+      pharmacology=(lab_info['pharmacology']
+            if 'pharmacology' in lab_info else ''),
+      related_publications=(lab_info['proj_pubs'] # list
+            if 'proj_pubs' in lab_info else []),
+      slices=(lab_info['slices']
+            if 'slices' in lab_info else ''),
+      source_script=(lab_info['repositoryurl']
+            if 'repositoryurl' in lab_info else ''),
+      surgery=(lab_info['surgery']
+            if 'surgery' in lab_info else ''),
+      virus=(lab_info['virus'] if 'virus' in lab_info else ''),
+      protocol=(lab_info['protocol']
+            if 'protocol' in lab_info else '')
+
+      ## AttributeError: 'str' object has no attribute 'parent'
+      ## Broz: I thought these were notes about the stimulus?
+      ##    Error indicates trying to process stim file itself?
+      # stimulus=(lab_info['stimulus']
+      #       if 'stimulus' in lab_info else []),
+
+
+      )

--- a/element_session/export/nwb.py
+++ b/element_session/export/nwb.py
@@ -31,39 +31,7 @@ def session_to_nwb(session_key,lab_key=None,project_key=None,protocol_key=None):
       identifier='_'.join(session_identifier.values()),
       session_description=session_info['session_note'] if session_info['session_note'] else '',
       session_start_time=session_info['session_datetime'],
+      source_script_file_name='DataJoint element-session/export/nwb.py',
       # experimenter=list(experimenters)
-
-      ## Lab info
-      ## Broz: How can I limit to only items that exist, avoiding blank entries?
-      institution=(lab_info['institution']
-            if 'institution' in lab_info else ''),
-      lab=(lab_info['lab_name']
-            if 'lab_name' in lab_info else ''),
-      experiment_description=(lab_info['project_description']
-            if 'project_description' in lab_info else ''),
-      keywords=(lab_info['proj_keyw'] # list
-            if 'proj_keyw' in lab_info else []),
-      notes=(lab_info['protocol_description']
-            if 'protocol_description' in lab_info else ''),
-      pharmacology=(lab_info['pharmacology']
-            if 'pharmacology' in lab_info else ''),
-      related_publications=(lab_info['proj_pubs'] # list
-            if 'proj_pubs' in lab_info else []),
-      slices=(lab_info['slices']
-            if 'slices' in lab_info else ''),
-      source_script=(lab_info['repositoryurl']
-            if 'repositoryurl' in lab_info else ''),
-      surgery=(lab_info['surgery']
-            if 'surgery' in lab_info else ''),
-      virus=(lab_info['virus'] if 'virus' in lab_info else ''),
-      protocol=(lab_info['protocol']
-            if 'protocol' in lab_info else '')
-
-      ## AttributeError: 'str' object has no attribute 'parent'
-      ## Broz: I thought these were notes about the stimulus?
-      ##    Error indicates trying to process stim file itself?
-      # stimulus=(lab_info['stimulus']
-      #       if 'stimulus' in lab_info else []),
-
-
+      **lab_info
       )

--- a/element_session/export/nwb.py
+++ b/element_session/export/nwb.py
@@ -24,9 +24,10 @@ def session_to_nwb(session_key):
                    session_description=session_info['session_note'] if session_info['session_note'] else '',
                    session_start_time=session_info['session_datetime'],
                    file_create_date=datetime.now(tzlocal()),
-                   experimenter=list(experimenters),
-                   data_collection='',
-                   institution='',
-                   experiment_description='',
-                   related_publications='',
-                   keywords=[])
+                   experimenter=list(experimenters)
+                   # data_collection='', # moved to elem-lab
+                   # institution='',
+                   # experiment_description='',
+                   # related_publications='',
+                   # keywords=[]
+                   )

--- a/element_session/session.py
+++ b/element_session/session.py
@@ -40,7 +40,7 @@ class Session(dj.Manual):
     """
 
     @classmethod
-    def make_nwb(cls, session_key, lab_key = None, project_key = None, protocol_key = None):
+    def make_nwb(cls, session_key):
         from .export import session_to_nwb
         nwb_session = session_to_nwb(session_key)
         nwb_session.subject = _linking_module.Subject.make_nwb(session_key)
@@ -56,13 +56,12 @@ class SessionDirectory(dj.Manual):
     """
 
 
-# @schema
-# class SessionExperimenter(dj.Manual):
-#     definition = """
-#     -> Session
-#     -> Experimenter # Broz: Where is this upstream? Reflected on another fork?
-#     """
-
+@schema
+class SessionExperimenter(dj.Manual):
+    definition = """
+    -> Session
+    -> Experimenter
+    """
 
 @schema
 class SessionNote(dj.Manual):

--- a/element_session/session.py
+++ b/element_session/session.py
@@ -40,7 +40,7 @@ class Session(dj.Manual):
     """
 
     @classmethod
-    def make_nwb(cls, session_key):
+    def make_nwb(cls, session_key, lab_key = None, project_key = None, protocol_key = None):
         from .export import session_to_nwb
         nwb_session = session_to_nwb(session_key)
         nwb_session.subject = _linking_module.Subject.make_nwb(session_key)
@@ -56,12 +56,12 @@ class SessionDirectory(dj.Manual):
     """
 
 
-@schema
-class SessionExperimenter(dj.Manual):
-    definition = """
-    -> Session
-    -> Experimenter
-    """
+# @schema
+# class SessionExperimenter(dj.Manual):
+#     definition = """
+#     -> Session
+#     -> Experimenter # Broz: Where is this upstream? Reflected on another fork?
+#     """
 
 
 @schema
@@ -69,7 +69,7 @@ class SessionNote(dj.Manual):
     definition = """
     -> Session
     ---
-    session_note: varchar(1000)
+    session_note: varchar(1024)
     """
 
 


### PR DESCRIPTION
- Calls on lab export function ([draft here](https://github.com/datajoint/element-lab/pull/11/files)) to get meta-information about lab, project, protocol. 

- Encountered error when populating a stimulus field which is [documentation suggests](https://nwb-schema.readthedocs.io/en/latest/format.html?highlight=stimulus#groups-stimulus) as freeform text. `AttributeError: 'str' object has no attribute 'parent'` - Or does this field expect the full [stimulus/presentation](https://nwb-schema.readthedocs.io/en/latest/format.html?highlight=stimulus#groups-stimulus) format? If attaching stim information, should that be stored as modality specific? Or perhaps with the trial behavior element?